### PR TITLE
New Pro tip. Eat heel first.

### DIFF
--- a/PbjProtips.txt
+++ b/PbjProtips.txt
@@ -1,2 +1,3 @@
 Protip: Use a spoon instead of a knife. It makes for easy scooping -- especially useful when using natural peanut butter with some oil separation -- and you can use the back of the spoon for spreading.
 ** Huge, additional benefit of being able to lick the spoon without fear of cutting your tongue once you've created your masterpiece. 
+Protip2: When opening a new loaf of bread, it is especially important to use one heel of the bread as part of your first PBJ. We all know this is not the best part of the bread, so it is best we get that out of the way and avoid being left with two heels at the end of the loaf.


### PR DESCRIPTION
Felt it necessary to add a pro tip that encourages the usage of the entire loaf of bread. In order to make sure we aren't leaving both heels to the end and then tossing both of them, I've suggested that the first sandwich of every new loaf include a heel. 